### PR TITLE
Upgarde version and Spring AI ChatClient to ChatModel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.3'
+    id 'org.springframework.boot' version '3.3.0'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 
@@ -34,9 +34,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.apache.commons:commons-csv:1.10.0'
     implementation 'org.jsoup:jsoup:1.16.1'
-    implementation 'redis.clients:jedis:4.4.3'
-    implementation 'com.google.firebase:firebase-admin:9.2.0'
-    implementation platform("org.springframework.ai:spring-ai-bom:0.8.0")
+    implementation 'redis.clients:jedis:5.1.3'
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
+    implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
     implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
     compileOnly 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/ac/knu/likeknujobserver/announcement/ai/OpenAIFineTuning.java
+++ b/src/main/java/ac/knu/likeknujobserver/announcement/ai/OpenAIFineTuning.java
@@ -2,10 +2,10 @@ package ac.knu.likeknujobserver.announcement.ai;
 
 import ac.knu.likeknujobserver.announcement.value.Tag;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.ai.chat.ChatClient;
-import org.springframework.ai.chat.ChatResponse;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.stereotype.Component;
 
@@ -15,16 +15,16 @@ import java.util.List;
 @Component
 public class OpenAIFineTuning {
 
-    private final ChatClient chatClient;
+    private final ChatModel chatModel;
 
-    public OpenAIFineTuning(ChatClient chatClient) {
-        this.chatClient = chatClient;
+    public OpenAIFineTuning(ChatModel chatModel) {
+        this.chatModel = chatModel;
     }
 
     public Tag abstractTagOfAnnouncement(String announcementTitle) {
         SystemMessage systemMessage = new SystemMessage("A bot that only speaks words that tag the entered sentence.");
         UserMessage userMessage = new UserMessage(announcementTitle);
-        ChatResponse chatResponse = chatClient.call(new Prompt(List.of(systemMessage, userMessage)));
+        ChatResponse chatResponse = chatModel.call(new Prompt(List.of(systemMessage, userMessage)));
         String content = chatResponse.getResult()
                 .getOutput()
                 .getContent();

--- a/src/main/java/ac/knu/likeknujobserver/configure/FirebaseInitializer.java
+++ b/src/main/java/ac/knu/likeknujobserver/configure/FirebaseInitializer.java
@@ -4,11 +4,13 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.io.FileInputStream;
 import java.io.IOException;
 
+@Profile("!test")
 @Component
 public class FirebaseInitializer {
 

--- a/src/test/java/ac/knu/likeknujobserver/LikeKnuJobServerApplicationTests.java
+++ b/src/test/java/ac/knu/likeknujobserver/LikeKnuJobServerApplicationTests.java
@@ -2,7 +2,9 @@ package ac.knu.likeknujobserver;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class LikeKnuJobServerApplicationTests {
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -17,5 +17,3 @@ rabbitmq.calendar-queue-name=knu.calendar
 
 spring.ai.openai.api-key=test
 spring.ai.openai.chat.options.model=test
-
-firebase.key-path=/Users/jcw1031/likeknu-2023-firebase-adminsdk-ehw5i-31d25209d8.json


### PR DESCRIPTION
### Upgrade Version
- Spring Boot version 3.2.3 -> 3.3.0
- Spring AI version 0.8.0 -> 1.0.0-SNAPSHOT
- jedis version 4.4.3 -> 5.1.3
- firebase-admin version 9.2.0 -> 9.3.0
<br>

### Remove deprecated chat object
- remove `ChatClient`, use `ChatModel` instead